### PR TITLE
Use raw ID for edges as well as vertices.

### DIFF
--- a/graphdb/DotParser.cpp
+++ b/graphdb/DotParser.cpp
@@ -154,8 +154,9 @@ public:
 	{
 	}
 
-	void OnStartEdge(int kind, const std::string & id, int _sourceID, int _targetID, const AttrMap & attrs)
+	void OnStartEdge(int kind, int _id, int _sourceID, int _targetID, const AttrMap & attrs)
 	{
+		std::string id = UIntToString(_id);
 		if (m_edgeStructs.find(id) == m_edgeStructs.end())
 		{
 			std::string sourceID = UIntToString(_sourceID);
@@ -163,7 +164,7 @@ public:
 			m_edgeStructs[id] = new CDotEdge(kind, id, sourceID, targetID, attrs);
 		}
 	}
-	void OnEndEdge(int kind, const std::string & id)
+	void OnEndEdge(int kind, int _id)
 	{
 	}
 

--- a/graphlayout/libagraph.cpp
+++ b/graphlayout/libagraph.cpp
@@ -196,9 +196,8 @@ void walkGraph(graph_t * g, IGraphvizVisitor * visitor, int depth)
 		{
 			gatherAttrs(e, attrs);
 
-			char buff[16];
-			visitor->OnStartEdge(g->kind, boost::lexical_cast<std::string>(e->id).c_str(), e->tail->id, e->head->id, attrs);
-			visitor->OnEndEdge(g->kind, buff);
+			visitor->OnStartEdge(g->kind, e->id, e->tail->id, e->head->id, attrs);
+			visitor->OnEndEdge(g->kind, e->id);
 		}
 		visitor->OnEndVertex(v->id);
 	}

--- a/graphlayout/libagraph.h
+++ b/graphlayout/libagraph.h
@@ -61,8 +61,8 @@ interface IGraphvizVisitor
 	virtual void OnStartVertex(int id, const AttrMap & attrs) = 0;
 	virtual void OnEndVertex(int id) = 0;
 
-	virtual void OnStartEdge(int kind, const std::string & id, int sourceID, int targetID, const AttrMap & attrs) = 0;
-	virtual void OnEndEdge(int kind, const std::string & id) = 0;
+	virtual void OnStartEdge(int kind, int id, int sourceID, int targetID, const AttrMap & attrs) = 0;
+	virtual void OnEndEdge(int kind, int id) = 0;
 };
 
 


### PR DESCRIPTION
Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
