### PR TITLE
gh-72 OSX Build Issue (Mountain Lion)

### DIFF
--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
@@ -605,7 +605,6 @@ bool HPCCSystemsGraphViewControl::onMouseMove(FB::MouseMoveEvent *evt, FB::Plugi
 
 bool HPCCSystemsGraphViewControl::onMouseScroll(FB::MouseScrollEvent *evt, FB::PluginWindow *)
 {
-    printf("onMouseScroll: %d\n", evt->m_state);
 	hpcc::PointD pt(evt->m_x, evt->m_y);
 	hpcc::PointD delta(evt->m_dx, evt->m_dy);
 	if (evt->m_state & FB::MouseButtonEvent::ModifierState_Control)
@@ -631,8 +630,8 @@ bool HPCCSystemsGraphViewControl::onMouseScroll(FB::MouseScrollEvent *evt, FB::P
 		hpcc::PointD worldDblClk(point.x, point.y);
 		worldDblClk = m_gr->ScreenToWorld(worldDblClk);
 
-		pt.x -= delta.x;
-		pt.y -= delta.y;
+		pt.x += delta.x;
+		pt.y += delta.y;
 
 		MoveTo(worldDblClk, pt.x, pt.y);
 	}
@@ -687,6 +686,9 @@ bool HPCCSystemsGraphViewControl::onRefresh(FB::RefreshEvent *evt, FB::PluginWin
 bool HPCCSystemsGraphViewControl::onWindowAttached(FB::AttachedEvent *evt, FB::PluginWindow *)
 {
     // The window is attached; act appropriately
+#if defined FB_WIN
+	((FB::PluginWindowWin*)GetWindow())->setSuppressEraseBackground(true);
+#endif
     return false;
 }
 

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.h
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.h
@@ -167,10 +167,10 @@ public:
     void testEvent();
 
 	//  Fire Events
-	FB_JSAPI_EVENT(Scaled, 1, (int));
+	FB_JSAPI_EVENT(Scaled, 1, (const int));
 	FB_JSAPI_EVENT(LayoutFinished, 0, ());
-	FB_JSAPI_EVENT(MouseDoubleClick, 1, (int));
-	FB_JSAPI_EVENT(SelectionChanged, 1, (FB::VariantList));
+	FB_JSAPI_EVENT(MouseDoubleClick, 1, (const int));
+	FB_JSAPI_EVENT(SelectionChanged, 1, (const FB::VariantList &));
 
 private:
     HPCCSystemsGraphViewControlWeakPtr m_plugin;

--- a/graphrender/osx_pixel_map.cpp
+++ b/graphrender/osx_pixel_map.cpp
@@ -109,7 +109,10 @@ namespace agg
         
         Rect	r;
     	int		row_bytes = calc_row_len (width, m_bpp);
-    	MacSetRect(&r, 0, 0, width, height);
+        r.left = 0;
+        r.top = 0;
+        r.right = width;
+        r.bottom = height;
     	m_buf = new unsigned char[m_img_size = row_bytes * height];
  		// The Quicktime version for creating GWorlds is more flexible than the classical function.
 //    	CGBitmapContextCreate (&m_pmap, m_bpp, &r, nil, nil, 0, m_buf, row_bytes);
@@ -167,7 +170,10 @@ namespace agg
         unsigned width  = (unsigned)(this->width() * scale);
         unsigned height = (unsigned)(this->height() * scale);
         Rect rect;
-        SetRect (&rect, x, y, x + width, y + height);
+        rect.left = x;
+        rect.top = y;
+        rect.right = x + width;
+        rect.bottom = y + height;
         draw(context, &rect);
     }
 


### PR DESCRIPTION
Removed MacSetRect and SetRect (as not supported by 1.8 SDK).
Scroll delta was inverted.
Added preferred "const" calling convention.
Disabled erase background on windows.

Fixes gh-72

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
