### PR TITLE
gh-65 Support boost versions >= 1.48

### DIFF
--- a/graphrender/FontResolver.cpp
+++ b/graphrender/FontResolver.cpp
@@ -122,8 +122,8 @@ protected:
 			{
 				if (boost::algorithm::iequals(boost::filesystem::extension(*itr), ext))
 				{
-					found[itr->path().stem()] = itr->path().native_file_string();
-					getFamilyName(itr->path().native_file_string());
+					found[itr->path().stem().string()] = itr->path().string();
+					getFamilyName(itr->path().string());
 				}
 
 				findFilesByExt(*itr, ext, found);

--- a/graphrender/precompiled_headers.h
+++ b/graphrender/precompiled_headers.h
@@ -57,7 +57,7 @@
 #include <boost/smart_ptr/detail/atomic_count.hpp>
 #include <boost/thread.hpp>
 #include <boost/algorithm/string.hpp>
-#define BOOST_FILESYSTEM_VERSION 2
+#define BOOST_FILESYSTEM_VERSION 3
 #include <boost/filesystem.hpp>
 
 #include <ft2build.h>


### PR DESCRIPTION
BOOST_FILESYSTEM_VERSION 2 is not supported in boost 1.48 (and greater).
Switched to use BOOST_FILESYSTEM_VERSION 3, which is supported from 1.44
onwards.

Fixes gh-65

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
