### PR TITLE
gh-76 Support 32/64bit simultaneous installs

### DIFF
--- a/HPCCSystemsGraphViewControl/CMakeLists.txt
+++ b/HPCCSystemsGraphViewControl/CMakeLists.txt
@@ -76,11 +76,7 @@ target_link_libraries(${PROJECT_NAME}
 
 include ( InstallRequiredSystemLibraries )
 
-if ( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_x86_64")
-else ()
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_i386")
-endif ()
+set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_${FB_PLATFORM_ARCH_NAME}")
 
 if ( "${HPCC_MATURITY}" STREQUAL "release" )
     set ( stagever "${HPCC_SEQUENCE}" )
@@ -101,6 +97,8 @@ set ( CPACK_PACKAGE_CONTACT "HPCCSystems <ossdevelopment@lexisnexis.com>" )
 set ( CPACK_DEBIAN_PACKAGE_MAINTAINER "HPCCSystems <ossdevelopment@lexisnexis.com>" )
 set ( CPACK_RESOURCE_FILE_LICENSE "${FB_PROJECTS_DIR}/License.txt" )
 set ( CPACK_RESOURCE_FILE_README "${FB_PROJECTS_DIR}/CPackReadMe.txt" )
+
+set ( CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} )
 
 include ( CPack )
 

--- a/HPCCSystemsGraphViewControl/Mac/bundle_template/Info.plist
+++ b/HPCCSystemsGraphViewControl/Mac/bundle_template/Info.plist
@@ -5,9 +5,9 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>${PLUGIN_NAME}</string>
+	<string>${FBSTRING_PluginName}</string>
 	<key>CFBundleGetInfoString</key>
-    <string>${PLUGIN_NAME} ${FBSTRING_PLUGIN_VERSION}, ${FBSTRING_LegalCopyright}</string>
+    <string>${FBSTRING_PluginName} ${FBSTRING_PLUGIN_VERSION}, ${FBSTRING_LegalCopyright}</string>
 	<key>CFBundleIdentifier</key>
     <string>com.${FBTYPELIB_NAME}.${FBSTRING_PluginName}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BRPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>${PLUGIN_NAME} ${FBSTRING_PLUGIN_VERSION}</string>
+    <string>${FBSTRING_PluginName} ${FBSTRING_PLUGIN_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
@@ -41,10 +41,10 @@
 	<key>WebPluginName</key>
 	<string>${FBSTRING_ProductName}</string>
 	<key>WebPluginDescription</key>
-	<string>${FBSTRING_FileDescription}</string>
+	<string>${FBSTRING_PluginDescription}</string>
 	<key>WebPluginMIMETypes</key>
 	<dict>
-@foreach (FBSTRING_MIMEType CUR_MIMETYPE FBSTRING_FileDescription CUR_DESC)
+@foreach (FBSTRING_MIMEType CUR_MIMETYPE FBSTRING_PluginDescription CUR_DESC)
 		<key>${CUR_MIMETYPE}</key>
 		<dict>
             <key>WebPluginExtensions</key>

--- a/HPCCSystemsGraphViewControl/Mac/bundle_template/InfoPlist.strings
+++ b/HPCCSystemsGraphViewControl/Mac/bundle_template/InfoPlist.strings
@@ -1,4 +1,4 @@
 /* Localized versions of Info.plist keys */
 
-CFBundleName = "${PLUGIN_NAME}.plugin";
+CFBundleName = "${FBSTRING_PluginName}.plugin";
 NSHumanReadableCopyright = "${FBSTRING_LegalCopyright}";

--- a/HPCCSystemsGraphViewControl/Mac/projectDef.cmake
+++ b/HPCCSystemsGraphViewControl/Mac/projectDef.cmake
@@ -37,30 +37,9 @@ target_link_libraries(${PROJECT_NAME}
     ${PLUGIN_INTERNAL_DEPS}
     )
 
-# Copy plugin to Plug-Ins directory:
-function(releasePlugin projectName pathToPlugin releaseDirectory)
- ADD_CUSTOM_COMMAND(
- TARGET ${PROJECT_NAME}
- POST_BUILD
- COMMAND mkdir -p ${releaseDirectory}/${projectName}.plugin
- )
- ADD_CUSTOM_COMMAND( TARGET ${PROJECT_NAME}
- POST_BUILD
- COMMAND cp -pr ${pathToPlugin} ${releaseDirectory}
- )
-endfunction()
- 
 # Current output
-set(PBIN "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${PROJECT_NAME}.plugin")
+set(PBIN "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${FBSTRING_PluginName}.plugin")
  
-# Uncomment one of the following releasePlugin() calls to install the plugin
-  
-# Copy plugin to ~/Library/Internet Plug-Ins (single user)
-# releasePlugin("${PROJECT_NAME}" "${PBIN}" "~/Library/Internet Plug-Ins")
- 
-# Copy plugin to /Library/Internet Plug-Ins (all users)
-# releasePlugin("${PROJECT_NAME}" "${PBIN}" "/Library/Internet Plug-Ins")
-
 install ( DIRECTORY ${PBIN} DESTINATION "." )
 
 set ( PLUGIN_INSTALL_PREFIX "/Library/Internet Plug-Ins" )

--- a/HPCCSystemsGraphViewControl/PluginConfig.cmake
+++ b/HPCCSystemsGraphViewControl/PluginConfig.cmake
@@ -28,6 +28,11 @@ set(FBControl_GUID 2FF57548-1DE4-4F32-B133-2B3FBDDBF909)
 set(IFBComJavascriptObject_GUID 19170988-05B7-4A75-B249-3F3F18533CDF)
 set(FBComJavascriptObject_GUID 8D2D03E7-DE42-4902-B3EA-A16FBE863BEF)
 set(IFBComEventSource_GUID E0C8280C-4448-45DF-A750-F1C5A8ED7C40)
+if ( FB_PLATFORM_ARCH_32 )
+    set(FBControl_WixUpgradeCode_GUID 1DD0D554-E642-402E-8330-88B8199562F8)
+else ( FB_PLATFORM_ARCH_32 )
+    set(FBControl_WixUpgradeCode_GUID 199562F8-E642-402E-8330-88B81DD0D554)
+endif ( FB_PLATFORM_ARCH_32 )
 
 # these are the pieces that are relevant to using it from Javascript
 set(ACTIVEX_PROGID "HPCCSystems.HPCCSystemsGraphViewControl")
@@ -41,7 +46,11 @@ set(FBSTRING_LegalCopyright "Copyright 2012 HPCC Systems")
 set(FBSTRING_PluginFileName "np${PLUGIN_NAME}.dll")
 set(FBSTRING_ProductName "HPCCSystemsGraphViewControl")
 set(FBSTRING_FileExtents "")
-set(FBSTRING_PluginName "HPCCSystemsGraphViewControl")
+if ( FB_PLATFORM_ARCH_32 )
+    set(FBSTRING_PluginName "HPCCSystemsGraphViewControl") # No 32bit postfix to maintain backward compatability.
+else ( FB_PLATFORM_ARCH_32 )
+    set(FBSTRING_PluginName "HPCCSystemsGraphViewControl_${FB_PLATFORM_ARCH_NAME}")
+endif ( FB_PLATFORM_ARCH_32 )
 set(FBSTRING_MIMEType "application/x-hpccsystemsgraphviewcontrol")
 
 # Uncomment this next line if you're not planning on your plugin doing

--- a/HPCCSystemsGraphViewControl/Win/WiX/HPCCSystemsGraphViewControlInstaller.wxs
+++ b/HPCCSystemsGraphViewControl/Win/WiX/HPCCSystemsGraphViewControlInstaller.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-    <Product Id="*" Name="${FBSTRING_PluginName}" Language="1033" Version="${FBSTRING_PLUGIN_VERSION}" Manufacturer="${FBSTRING_CompanyName}" UpgradeCode="{cb291cb6-92ff-574b-b34b-97e64abc0afc}">
-        <Package InstallerVersion="200" Compressed="yes" Description="Installer for the ${PLUGIN_NAME} plugin" InstallScope="perUser" />
+    <Product Id="*" Name="${FBSTRING_PluginName}" Language="1033" Version="${FBSTRING_PLUGIN_VERSION}" Manufacturer="${FBSTRING_CompanyName}" UpgradeCode="{${FBControl_WixUpgradeCode_GUID}}">
+        <Package InstallerVersion="200" Compressed="yes" Description="Installer for the ${FBSTRING_PluginName} plugin" InstallScope="perUser" />
         <Upgrade Id="{cb291cb6-92ff-574b-b34b-97e64abc0afc}">
             <UpgradeVersion
                 Property="OLD_VERSION_FOUND"
@@ -30,7 +30,7 @@
                             Value="${FBSTRING_PLUGIN_VERSION}"
                             KeyPath="yes" />
                     </Component>
-                    <Directory Id="PluginNameDir" Name="${PLUGIN_NAME}">
+                    <Directory Id="PluginNameDir" Name="${FBSTRING_PluginName}">
                         <Component Id="PluginNameDirComp" Guid="*">
                             <RemoveFolder Id="RemovePluginNameDir" On="uninstall" />
                             <RegistryValue

--- a/README
+++ b/README
@@ -14,7 +14,7 @@ git clone https://github.com/hpcc-systems/GraphControl.git
 # Get Firebreath library
 git clone https://github.com/GordonSmith/FireBreath.git
 cd FireBreath
-git checkout X11_Support
+git checkout HPCCSystems
 cd ..
 
 # Get unrestricted (2.4) agg libraries


### PR DESCRIPTION
Both OSX and Windows need to support simultaneous installs of the 32 and 64 bit
versions.

Fixes gh-76

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
