### PR TITLE
Issue_103 Label generation ignores historic properties

### DIFF
--- a/HPCCSystemsGraphViewControl/Factory.cpp
+++ b/HPCCSystemsGraphViewControl/Factory.cpp
@@ -20,9 +20,10 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include <boost/algorithm/string.hpp>
+
 #include "FactoryBase.h"
 #include "HPCCSystemsGraphViewControl.h"
-#include <boost/make_shared.hpp>
 
 class PluginFactory : public FB::FactoryBase
 {

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include <boost/algorithm/string.hpp>
+
 #include "HPCCSystemsGraphViewControlAPI.h"
 
 #include "HPCCSystemsGraphViewControl.h"
@@ -33,7 +35,6 @@
 
 #include <XgmmlParser.h>
 #include <DotParser.h>
-#include <boost/algorithm/string.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @fn HPCCSystemsGraphViewControl::StaticInitialize()
@@ -470,7 +471,7 @@ const hpcc::IClusterSet & HPCCSystemsGraphViewControl::GetClusters()
 	return m_g->GetClusters();
 }
 
-int HPCCSystemsGraphViewControl::GetProperties(int _item, hpcc::StringStringMap & results)
+int HPCCSystemsGraphViewControl::GetProperties(int _item, hpcc::ciStringStringMap & results)
 {
 	hpcc::IGraphItemPtr item = m_g->GetGraphItem(_item);
 	if (item)

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.h
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.h
@@ -122,7 +122,7 @@ public:
 	bool SetSelected(const std::vector<int> & items, bool clearPrevious);
 	bool SetSelected(const std::vector<std::string> & items, bool clearPrevious);
 	const hpcc::IClusterSet & GetClusters();
-	int GetProperties(int item, hpcc::StringStringMap & results);
+	int GetProperties(int item, hpcc::ciStringStringMap & results);
 	unsigned int GetItem(const std::string &externalID);
 	const char * GetGlobalID(int item);
 	int GetClusters(std::vector<int> & results);

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.cpp
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  ******************************************************************************/
 
+#include <boost/algorithm/string.hpp>
+
 #include "JSObject.h"
 #include "variant_list.h"
 #include "DOM/Document.h"
@@ -27,7 +29,6 @@
 
 #include "HPCCSystemsGraphViewControlAPI.h"
 #include <XgmmlParser.h>
-#include <boost/algorithm/string.hpp>
 
 #include "Version.h"
 
@@ -215,9 +216,9 @@ FB::VariantMap HPCCSystemsGraphViewControlAPI::getProperties(int item)
 	retVal["_internalID"] = item;
 	retVal["_globalID"] = getGlobalID(item);
 
-	hpcc::StringStringMap properties;
+	hpcc::ciStringStringMap properties;
 	getPlugin()->GetProperties(item, properties);
-	for(hpcc::StringStringMap::const_iterator itr = properties.begin(); itr != properties.end(); ++itr)
+	for(hpcc::ciStringStringMap::const_iterator itr = properties.begin(); itr != properties.end(); ++itr)
 		retVal[itr->first] = itr->second;
 
 	return retVal;
@@ -234,7 +235,7 @@ FB::VariantList HPCCSystemsGraphViewControlAPI::getPropertiesForItems(const std:
 
 std::string HPCCSystemsGraphViewControlAPI::getProperty(int item, const std::string & key)
 {
-	hpcc::StringStringMap properties;
+	hpcc::ciStringStringMap properties;
 	getPlugin()->GetProperties(item, properties);
 	return properties[key];
 }

--- a/graphdb/GraphDB.cpp
+++ b/graphdb/GraphDB.cpp
@@ -251,9 +251,9 @@ std::string xmlEncode(const std::string & text)
 const char * BuildVertexString(const IVertex * vertex, std::string &vertexStr, bool isPoint)
 {
 	std::string attrStr, propsStr;
-	StringStringMap props;
+	ciStringStringMap props;
 	vertex->GetProperties(props);
-	for(StringStringMap::const_iterator itr = props.begin(); itr != props.end(); ++itr)
+	for(ciStringStringMap::const_iterator itr = props.begin(); itr != props.end(); ++itr)
 	{
 		if (isPoint && boost::algorithm::iequals(itr->first, "_kind"))
 			propsStr += "<att name=\"_kind\" value=\"point\"/>";
@@ -270,9 +270,9 @@ const char * BuildVertexString(const IVertex * vertex, std::string &vertexStr, b
 const char * BuildEdgeString(const IEdge * edge, std::string &edgeStr)
 {
 	std::string attrStr, propsStr;
-	StringStringMap props;
+	ciStringStringMap props;
 	edge->GetProperties(props);
-	for(StringStringMap::const_iterator itr = props.begin(); itr != props.end(); ++itr)
+	for(ciStringStringMap::const_iterator itr = props.begin(); itr != props.end(); ++itr)
 	{
 		if (boost::algorithm::iequals(itr->first, "id") ||
 			boost::algorithm::iequals(itr->first, "label") ||

--- a/graphdb/GraphDB.h
+++ b/graphdb/GraphDB.h
@@ -56,6 +56,13 @@ typedef CUnknownPtr<IEdge> IEdgePtr;
 typedef std::set<IEdgePtr, CompareT<IEdgePtr> > IEdgeSet;
 
 typedef std::map<std::string, std::string> StringStringMap;
+struct ciLessBoost : std::binary_function<std::string, std::string, bool>
+{
+    bool operator() (const std::string & s1, const std::string & s2) const {
+        return boost::lexicographical_compare(s1, s2, boost::is_iless());
+    }
+};
+typedef std::map<std::string, std::string, ciLessBoost> ciStringStringMap;
 
 //  ===========================================================================
 enum PROP
@@ -112,8 +119,9 @@ hpcc_interface GRAPHDB_API IGraphItem : public IUnknown
 	virtual CUnknown * GetPropertyCUnknown(unsigned int key) const = 0;
 
 	virtual void SetProperty(const std::string & key, const std::string & val) = 0;
+	virtual bool HasProperty(const std::string & key) const = 0;
 	virtual const char * GetProperty(const std::string & key) const = 0;
-	virtual int GetProperties(StringStringMap & results) const = 0;
+	virtual int GetProperties(ciStringStringMap & results) const = 0;
 };
 
 hpcc_interface GRAPHDB_API ICluster : public IGraphItem

--- a/graphdb/GraphItem.cpp
+++ b/graphdb/GraphItem.cpp
@@ -169,13 +169,19 @@ void CGraphItem::SetProperty(const std::string & key, const std::string & val)
 
 const char * CGraphItem::GetProperty(const std::string & key) const
 {
-	StringStringMap::const_iterator found = m_propStringString.find(key);
+	ciStringStringMap::const_iterator found = m_propStringString.find(key);
 	if (found != m_propStringString.end())
 		return found->second.c_str();
 	return NULL;
 }
 
-int CGraphItem::GetProperties(StringStringMap & results) const 
+bool CGraphItem::HasProperty(const std::string & key) const
+{
+	ciStringStringMap::const_iterator found = m_propStringString.find(key);
+	return found != m_propStringString.end();
+}
+
+int CGraphItem::GetProperties(ciStringStringMap & results) const
 { 
 	results = m_propStringString;
 	return results.size();

--- a/graphdb/GraphItem.h
+++ b/graphdb/GraphItem.h
@@ -47,7 +47,7 @@ protected:
 	IntIUnknownMap m_propIUnknown;
 	IntCUnknownMap m_propCUnknown;
 
-	StringStringMap m_propStringString;
+	ciStringStringMap m_propStringString;
 
 	std::string m_blankString;
 	
@@ -84,8 +84,9 @@ public:
 	CUnknown * GetPropertyCUnknown(unsigned int key) const;
 
 	void SetProperty(const std::string & key, const std::string & val);
+	bool HasProperty(const std::string & key) const;
 	const char * GetProperty(const std::string & key) const;
-	int GetProperties(StringStringMap & results) const;
+	int GetProperties(ciStringStringMap & results) const;
 };
 typedef CUnknownPtr<CGraphItem> CGraphItemPtr;
 typedef std::map<unsigned int, CGraphItemPtr> IDGraphItemMap;
@@ -107,6 +108,7 @@ typedef std::map<unsigned int, CGraphItemPtr> IDGraphItemMap;
 						void SetProperty(unsigned int key, CUnknown * val) { CGraphItem::SetProperty(key, val); } \
 						CUnknown * GetPropertyCUnknown(unsigned int key) const { return CGraphItem::GetPropertyCUnknown(key); } \
 						void SetProperty(const std::string & key, const std::string & val) { CGraphItem::SetProperty(key, val); } \
+						bool HasProperty(const std::string & key) const { return CGraphItem::HasProperty(key); } \
 						const char * GetProperty(const std::string & key) const { return CGraphItem::GetProperty(key); } \
-						int GetProperties(StringStringMap & results) const { return CGraphItem::GetProperties(results); }
+						int GetProperties(ciStringStringMap & results) const { return CGraphItem::GetProperties(results); }
 }

--- a/graphdb/SaxParser.h
+++ b/graphdb/SaxParser.h
@@ -25,6 +25,7 @@
 
 #include "expat.h"
 #include "util.h"
+#include "GraphItem.h"
 
 namespace hpcc
 {
@@ -456,13 +457,6 @@ protected:
 	XML_Parser m_p;
 };
 
-struct ciLessBoost : std::binary_function<std::string, std::string, bool> 
-{ 
-    bool operator() (const std::string & s1, const std::string & s2) const { 
-        return boost::lexicographical_compare(s1, s2, boost::is_iless()); 
-    } 
-}; 
-typedef std::map<std::string, std::string, ciLessBoost> ciStringStringMap;
 class CElement : public CUnknown
 {
 protected:

--- a/graphdb/SvgParser.cpp
+++ b/graphdb/SvgParser.cpp
@@ -237,7 +237,7 @@ GRAPHDB_API bool MergeSVG(IGraph * graph, const std::string & svg)
 	try
 	{
 		parser.Parse(svg.c_str(), svg.length());
-	} catch (ParseException & e) {
+	} catch (ParseException &) {
 		return false;
 	}
 	RectD childRect;

--- a/graphdb/XgmmlParser.cpp
+++ b/graphdb/XgmmlParser.cpp
@@ -259,11 +259,11 @@ public:
 			for(ciStringStringMap::const_iterator itr = e->m_attr.begin(); itr != e->m_attr.end(); ++itr)
 				edge->SetProperty(itr->first, itr->second);
 
-			std::string prettyCount = constGet(e->m_attr, "count");
-			if (prettyCount.length() && 
+			std::string prettyCount = edge->GetProperty("count");
+			if (!prettyCount.empty() &&
 					(!boost::algorithm::equals(prettyCount, "0") || 
-					(boost::algorithm::equals(prettyCount, "0") && boost::algorithm::equals(constGet(e->m_attr, "_eofSeen"), "1")) || 
-					(boost::algorithm::equals(prettyCount, "0") && boost::algorithm::equals(constGet(e->m_attr, "started"), "1"))))
+					(boost::algorithm::equals(prettyCount, "0") && boost::algorithm::equals(edge->GetProperty("_eofSeen"), "1")) ||
+					(boost::algorithm::equals(prettyCount, "0") && boost::algorithm::equals(edge->GetProperty("started"), "1"))))
 			{
 				std::string tmp;
 				int len = prettyCount.length();
@@ -279,16 +279,16 @@ public:
 				prettyCount = "";
 
 			std::string edgeLabel;
-			if (constGet(e->m_attr, "label").length() && prettyCount.length() && constGet(e->m_attr, "maxskew").length() && constGet(e->m_attr, "minskew").length())
-				edgeLabel = (boost::format("%1%\n%2%\n+%3%%%, -%4%%%") % constGet(e->m_attr, "label") % prettyCount % constGet(e->m_attr, "maxskew") % constGet(e->m_attr, "minskew")).str();
-			else if (prettyCount.length() && constGet(e->m_attr, "maxskew").length() && constGet(e->m_attr, "minskew").length())
-				edgeLabel = (boost::format("%1%\n+%2%%%, -%3%%%") % prettyCount % constGet(e->m_attr, "maxskew") % constGet(e->m_attr, "minskew")).str();
-			else if (constGet(e->m_attr, "label").length() && prettyCount.length())
-				edgeLabel = (boost::format("%1%\n%2%") % constGet(e->m_attr, "label") % prettyCount).str();
-			else if (prettyCount.length())
+			if (!prettyCount.empty() && edge->HasProperty("label") && edge->HasProperty("maxskew") && edge->HasProperty("minskew"))
+				edgeLabel = (boost::format("%1%\n%2%\n+%3%%%, -%4%%%") % edge->GetProperty("label") % prettyCount % edge->GetProperty("maxskew") % edge->GetProperty("minskew")).str();
+			else if (!prettyCount.empty() && edge->HasProperty("maxskew") && edge->HasProperty("minskew"))
+				edgeLabel = (boost::format("%1%\n+%2%%%, -%3%%%") % prettyCount % edge->GetProperty("maxskew") % edge->GetProperty("minskew")).str();
+			else if (!prettyCount.empty() && edge->HasProperty("label"))
+				edgeLabel = (boost::format("%1%\n%2%") % edge->GetProperty("label") % prettyCount).str();
+			else if (!prettyCount.empty())
 				edgeLabel = (boost::format("%1%") % prettyCount).str();
-			else if (constGet(e->m_attr, "label").length())
-				edgeLabel = (boost::format("%1%") % constGet(e->m_attr, "label")).str();
+			else if (edge->HasProperty("label"))
+				edgeLabel = (boost::format("%1%") % edge->GetProperty("label")).str();
 
 			boost::algorithm::replace_all(edgeLabel, "\n", "\\n");
 			if (edgeLabel.empty())
@@ -297,11 +297,11 @@ public:
 			if (m_merge)
 				UpdateVisibleLabel(edge, edgeLabel);
 
-			if (boost::algorithm::equals(constGet(e->m_attr, "_dependsOn"), "1") || boost::algorithm::equals(constGet(e->m_attr, "_childGraph"), "1"))
+			if (boost::algorithm::equals(edge->GetProperty("_dependsOn"), "1") || boost::algorithm::equals(edge->GetProperty("_childGraph"), "1"))
 				edge->SetProperty(DOT_EDGE_STYLE, "dashed");
 
-			std::string started = constGet(e->m_attr, "started");
-			std::string stopped = constGet(e->m_attr, "stopped");
+			std::string started = edge->GetProperty("started");
+			std::string stopped = edge->GetProperty("stopped");
 			if (started.empty() && stopped.empty())
 			{
 				edge->SetProperty(XGMML_STATE, XGMML_STATE_UNKNOWN);


### PR DESCRIPTION
The label is created during the XGMML parsing stage and will ignore historic properties (specifically maxSkew/minSkew).

This can cause inconsistencies between the main graph, local graph and properties.

Fixes Issue_103

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
