### PR TITLE
GH-105 Modified package name generation to match HPCC

### DIFF
--- a/HPCCSystemsGraphViewControl/CMakeLists.txt
+++ b/HPCCSystemsGraphViewControl/CMakeLists.txt
@@ -115,24 +115,41 @@ link_boost_library ( ${PROJECT_NAME} regex )
 
 install ( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib )
 
-####  CPACK  ####
-set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_${FB_PLATFORM_ARCH_NAME}")
+##############################################
+# Build tag generation
 
-if ( "${HPCC_MATURITY}" STREQUAL "release" )
-    set ( stagever "${HPCC_SEQUENCE}" )
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set ( ARCH64BIT 1 )
 else ()
-    set ( stagever "${HPCC_SEQUENCE}${HPCC_MATURITY}" )
+    set ( ARCH64BIT 0 )
 endif ()
+message ("-- 64bit architecture is ${ARCH64BIT}")
 
-if ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
-    set ( stagever "${stagever}-Debug" )
-endif ( "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" )
+set(projname ${HPCC_PROJECT})
+set(majorver ${HPCC_MAJOR})
+set(minorver ${HPCC_MINOR})
+set(point ${HPCC_POINT})
+if ( "${HPCC_MATURITY}" STREQUAL "release" )
+    set(stagever "${HPCC_SEQUENCE}")
+else()
+    set(stagever "${HPCC_MATURITY}${HPCC_SEQUENCE}")
+endif()
+set(version ${majorver}.${minorver}.${point})
+
+IF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    set( stagever "${stagever}-Debug" )
+ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+##############################################
+
+####  CPACK  ####
+INCLUDE(InstallRequiredSystemLibraries)
+set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_${FB_PLATFORM_ARCH_NAME}")
 
 set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )
 set ( CPACK_PACKAGE_NAME "hpccsystems-graphcontrol" )
-set ( CPACK_PACKAGE_VERSION_MAJOR ${HPCC_MAJOR} )
-set ( CPACK_PACKAGE_VERSION_MINOR ${HPCC_MINOR} )
-set ( CPACK_PACKAGE_VERSION_PATCH ${HPCC_POINT}-${stagever} )
+SET(CPACK_PACKAGE_VERSION_MAJOR ${majorver})
+SET(CPACK_PACKAGE_VERSION_MINOR ${minorver})
+SET(CPACK_PACKAGE_VERSION_PATCH ${point}${stagever})
 set ( CPACK_PACKAGE_DESCRIPTION_SUMMARY "HPCC Systems Graph Control." )
 
 set ( CPACK_PACKAGE_CONTACT "HPCCSystems <ossdevelopment@lexisnexis.com>" )
@@ -141,6 +158,73 @@ set ( CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-dev (>=1.46.0), libboost-system-dev
 
 set ( CPACK_RESOURCE_FILE_LICENSE "${FB_PROJECTS_DIR}/License.txt" )
 set ( CPACK_RESOURCE_FILE_README "${FB_PROJECTS_DIR}/CPackReadMe.txt" )
+
+
+set ( CPACK_RPM_PACKAGE_VERSION "${projname}")
+SET(CPACK_RPM_PACKAGE_RELEASE "${version}${stagever}")
+if ( ${ARCH64BIT} EQUAL 1 )
+    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+else( ${ARCH64BIT} EQUAL 1 )
+    set ( CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
+endif ( ${ARCH64BIT} EQUAL 1 )
+set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${CPACK_RPM_PACKAGE_ARCHITECTURE}")
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    set(CPACK_STRIP_FILES TRUE)
+endif()
+if ( APPLE )
+elseif ( UNIX )
+    EXECUTE_PROCESS (
+                COMMAND ${FB_PROJECTS_DIR}/cmake_utils/distrocheck.sh
+                    OUTPUT_VARIABLE packageManagement
+                        ERROR_VARIABLE  packageManagement
+                )
+    EXECUTE_PROCESS (
+                COMMAND ${FB_PROJECTS_DIR}/cmake_utils/getpackagerevisionarch.sh
+                    OUTPUT_VARIABLE packageRevisionArch
+                        ERROR_VARIABLE  packageRevisionArch
+                )
+    EXECUTE_PROCESS (
+                COMMAND ${FB_PROJECTS_DIR}/cmake_utils/getpackagerevisionarch.sh --noarch
+                    OUTPUT_VARIABLE packageRevision
+                        ERROR_VARIABLE  packageRevision
+                )
+
+    message ( "-- Auto Detecting Packaging type")
+    message ( "-- distro uses ${packageManagement}, revision is ${packageRevisionArch}" )
+    
+    if ( "${packageManagement}" STREQUAL "DEB" )
+        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}${packageRevisionArch}")
+    elseif ( "${packageManagement}" STREQUAL "RPM" )
+        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}-${version}-${stagever}.${packageRevisionArch}")
+    else()
+        set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}${CPACK_SYSTEM_NAME}")
+    endif ()
+endif ()
+MESSAGE ("-- Current release version is ${CPACK_PACKAGE_FILE_NAME}")
+
+###
+## Run file configuration to set build tag along with install lines for generated
+## config files.
+###
+set( BUILD_TAG "${CPACK_RPM_PACKAGE_VERSION}_${version}-${stagever}")
+if (USE_GIT_DESCRIBE OR CHECK_GIT_TAG)
+    FETCH_GIT_TAG (${CMAKE_SOURCE_DIR} ${CPACK_RPM_PACKAGE_VERSION}_${version} GIT_BUILD_TAG)
+    message ("-- Git tag is '${GIT_BUILD_TAG}'")
+    if (NOT "${GIT_BUILD_TAG}" STREQUAL "${BUILD_TAG}")
+        if (CHECK_GIT_TAG)
+            message(FATAL_ERROR "Git tag '${GIT_BUILD_TAG}' does not match source version '${BUILD_TAG}'" )
+        else()
+            if(NOT "${GIT_BUILD_TAG}" STREQUAL "") # probably means being built from a tarball...
+                set( BUILD_TAG "${BUILD_TAG}[${GIT_BUILD_TAG}]")
+            endif()
+        endif()
+    endif()
+endif()
+message ("-- Build tag is '${BUILD_TAG}'")
+if (NOT "${BASE_BUILD_TAG}" STREQUAL "")
+    set(BASE_BUILD_TAG "${BUILD_TAG}")
+endif()
+message ("-- Base build tag is '${BASE_BUILD_TAG}'")
 
 if ( UNIX )
     set ( CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} )

--- a/cmake_utils/distrocheck.sh
+++ b/cmake_utils/distrocheck.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+#############################################
+#    HPCC SYSTEMS software Copyright (C) 2012 HPCC Systems.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#
+#    limitations under the License.
+#    along with All rights reserved. This program is free software: you can redistribute program.  If not, see <http://www.gnu.org/licenses/>.
+#############################################
+
+if [ -e /etc/debian_version ]; then
+    echo -n "DEB"
+    exit 2;
+elif [ -e /etc/redhat-release ]; then
+    echo -n "RPM"
+    exit 1;
+elif [ -e /etc/SuSE-release ]; then
+    echo -n "RPM"
+    exit 1;
+fi
+
+cat /etc/*release > temp.txt
+
+############### RPM DISTROS ##################
+
+# Distribution is openSuse
+VALUE=`grep -c -i 'suse' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "RPM"
+    rm temp.txt
+    exit 1;
+fi
+
+# Distribution is Centos
+VALUE=`grep -c -i 'centos' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "RPM"
+    rm temp.txt
+    exit 1;
+fi
+
+# Distribution is Mandriva 
+VALUE=`grep -c -i 'mandr' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "RPM"
+    rm temp.txt
+    exit 1;
+fi
+
+# Distribution is Redhat
+VALUE=`grep -c -i 'redhat' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "RPM"
+    rm temp.txt
+    exit 1;
+fi
+
+############### DEB DISTROS ##################
+
+# Distribution is Ubuntu
+VALUE=`grep -c -i 'ubuntu' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "DEB"
+    rm temp.txt
+    exit 2;
+fi
+
+# Distribution is Debian
+VALUE=`grep -c -i 'DEBian' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "DEB"
+    rm temp.txt
+    exit 2;
+fi
+
+
+############## OTHER DISTROS #################
+
+# Distribution is Gentoo
+VALUE=`grep -c -i 'gentoo' temp.txt` 
+if [ $VALUE -ge 1 ]; then
+    echo -n "TGZ"
+    rm temp.txt
+    exit 4;
+fi
+

--- a/cmake_utils/getpackagerevisionarch.sh
+++ b/cmake_utils/getpackagerevisionarch.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+print_usage(){
+    echo "usage: getpackagerevisionarch.sh [-n|--noarch] "
+    exit 1
+}
+
+NOARCH=0
+TEMP=`/usr/bin/getopt -o nh --long help,noarch -n 'getpackagerevisionarch.sh' -- "$@"`
+if [ $? != 0 ] ; then echo "Failure to parse commandline." >&2 ; exit 1 ; fi
+eval set -- "$TEMP"
+while true ; do
+    case "$1" in
+	-n|--noarch) NOARCH=1
+	    shift ;;
+        -h|--help) print_usage
+                   shift ;;
+        --) shift ; break ;;
+        *) print_usage ;;
+    esac
+done
+
+OUTPUT=""
+ARCH=`uname -m`
+ARCH2=${ARCH}
+case "$ARCH" in
+  "x86_64")
+     ARCH="x86_64"
+     ARCH2="amd64"
+     ;;
+   "i386" | "i686")
+     ARCH="i386"
+     ARCH2="i386"
+     ;;
+esac
+
+
+if [ -e /etc/debian_version ]; then
+  if [ -e /etc/lsb-release ]; then
+    . /etc/lsb-release
+    if [ ${NOARCH} -eq 0 ]; then
+        OUTPUT="${DISTRIB_CODENAME}_${ARCH2}"
+    else
+        OUTPUT="${DISTRIB_CODENAME}"
+    fi
+  else
+    case `cat /etc/debian_version` in
+      5.*)
+        if [ ${NOARCH} -eq 0 ]; then
+            OUTPUT="lenny_${ARCH2}"
+        else
+            OUTPUT="lenny"
+        fi
+        ;;
+      6.*)
+        if [ ${NOARCH} -eq 0 ]; then
+            OUTPUT="squeeze_${ARCH2}"
+        else
+            OUTPUT="squeeze"
+        fi
+        ;;
+      "sid")
+        if [ ${NOARCH} -eq 0 ]; then
+            OUTPUT="sid_${ARCH2}"
+        else
+            OUTPUT="sid"
+        fi
+        ;;
+    esac
+  fi
+elif [ -e /etc/redhat-release ]; then
+  if [ -x /bin/rpm ]; then
+    OUTPUT="${OUTPUT}\npackage=rpm"
+    OS_GROUP=`/bin/rpm -q --qf "%{NAME}" --whatprovides /etc/redhat-release | sed 's/-release.*//' |  tr '[A-Z]' '[a-z]'`
+    REDHAT_VERSION=`/bin/rpm -q --qf "%{VERSION}" --whatprovides /etc/redhat-release`
+    case "$OS_GROUP" in
+      "centos" | "fedora")
+        if [ ${NOARCH} -eq 0 ]; then
+            OUTPUT="el${REDHAT_VERSION}.${ARCH}"
+        else
+            OUTPUT="el${REDHAT_VERSION}"
+        fi
+        ;;
+      "redhat")
+        REDHAT_RELEASE=`/bin/rpm -q --qf "%{RELEASE}" --whatprovides /etc/redhat-release| cut -d. -f1`
+        if [ ${NOARCH} -eq 0 ]; then
+            OUTPUT="el${REDHAT_VERSION}.${ARCH}"
+        else
+            OUTPUT="el${REDHAT_VERSION}"
+        fi
+        ;;
+      esac
+    fi
+elif [ -e /etc/SuSE-release ]; then
+  if [ -x /bin/rpm ]; then
+    OS_GROUP=`/bin/rpm -q --qf "%{NAME}" --whatprovides /etc/SuSE-release | sed 's/-release.*//' |  tr '[A-Z]' '[a-z]'`
+    REDHAT_VERSION=`/bin/rpm -q --qf "%{VERSION}" --whatprovides /etc/SuSE-release`
+      case "$OS_GROUP" in
+        "opensuse" )
+          if [ ${NOARCH} -eq 0 ]; then
+              OUTPUT="suse${REDHAT_VERSION}.${ARCH}"
+          else
+              OUTPUT="suse${REDHAT_VERSION}"
+          fi
+          ;;
+      esac
+  fi
+elif [ -e /etc/gentoo-release ]; then
+  OUTPUT="gentoo"
+else
+  exit 0
+fi
+
+echo -n $OUTPUT
+


### PR DESCRIPTION
Added scripts used to generate the distribution and arch of a system.
Added common code from HPCC that allows for matching versioning and package
naming.

Signed-off-by: Philip Schwartz philip.schwartz@lexisnexis.com
