### PR TITLE
gh-108 Building WITH_HPCC_RUNTIME=TRUE

### DIFF
--- a/HPCCSystemsGraphViewControl/CMakeLists.txt
+++ b/HPCCSystemsGraphViewControl/CMakeLists.txt
@@ -10,6 +10,9 @@ set (CMAKE_BACKWARDS_COMPATIBILITY 2.6)
 
 Project ( ${PLUGIN_NAME} )
 
+SET ( EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin/HPCCSystemsGraphViewControl" CACHE PATH "Location of BIN files" )
+SET ( LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin/HPCCSystemsGraphViewControl" CACHE PATH "Location of LIB files" )
+
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/Version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/Version.h )
 
 file (GLOB GENERAL RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -99,6 +102,7 @@ if(WIN32)
 elseif(APPLE)
 elseif(UNIX)
 endif()
+add_definitions( -DBOOST_ALL_NO_LIB )
 
 add_subdirectory ("${FB_PROJECTS_DIR}/graphlayout" "graphlayout")
 add_subdirectory ("${FB_PROJECTS_DIR}/graphdb" "graphdb")

--- a/graphdb/CMakeLists.txt
+++ b/graphdb/CMakeLists.txt
@@ -72,8 +72,9 @@ ADD_PRECOMPILED_HEADER(${PROJECT_NAME} "precompiled_headers.h" "precompiled_head
 target_link_libraries ( graphdb 
 	graphlayout 
 	expat 
-	${Boost_LIBRARIES}
 	)
+link_boost_library ( ${PROJECT_NAME} date_time )
+link_boost_library ( ${PROJECT_NAME} system )
 
 # *********************************************************************
 

--- a/graphrender/CMakeLists.txt
+++ b/graphrender/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries ( graphrender
 	graphdb 
 	agg
 	)
+link_boost_library ( ${PROJECT_NAME} filesystem )
 
 # *********************************************************************
 


### PR DESCRIPTION
Using different combinations of WITH_HPCC_RUNTIME and WITH_DYNAMIC_MSVC_RUNTIME
would not always build cleanly.

Fixes gh-108

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
