### PR TITLE
IDE-249 Add CPack Support

### DIFF
--- a/graphlayout/CMakeLists.txt
+++ b/graphlayout/CMakeLists.txt
@@ -129,6 +129,12 @@ target_link_libraries ( graphlayout
 	xdot
 	vpsc
 	)
+link_boost_library ( ${PROJECT_NAME} thread )
+link_boost_library ( ${PROJECT_NAME} system )
+if (Boost_MAJOR_VERSION GREATER 0 AND Boost_MINOR_VERSION GREATER 47)
+    link_boost_library( ${PROJECT_NAME} chrono)
+endif ()
+
 
 # *********************************************************************
 


### PR DESCRIPTION
GraphControl is not building correctly when runtime dlls are enabled.

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
