### PR TITLE
gh-123 Windows cpack package is missing main dll

### DIFF
--- a/HPCCSystemsGraphViewControl/CMakeLists.txt
+++ b/HPCCSystemsGraphViewControl/CMakeLists.txt
@@ -147,7 +147,10 @@ ENDIF ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
 ##############################################
 
 ####  CPACK  ####
-INCLUDE(InstallRequiredSystemLibraries)
+if ( WIN32 AND WITH_DYNAMIC_MSVC_RUNTIME )
+    include ( InstallRequiredSystemLibraries )
+endif ( WIN32 AND WITH_DYNAMIC_MSVC_RUNTIME )
+
 set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}_${FB_PLATFORM_ARCH_NAME}")
 
 set ( CPACK_PACKAGE_VENDOR "HPCC Systems" )

--- a/HPCCSystemsGraphViewControl/Win/projectDef.cmake
+++ b/HPCCSystemsGraphViewControl/Win/projectDef.cmake
@@ -56,18 +56,4 @@ set(WIX_HEAT_FLAGS
     -dr INSTALLDIR      # Set the directory ID to put the files in
     )
 
-add_wix_installer( ${PLUGIN_NAME}
-    ${CMAKE_CURRENT_SOURCE_DIR}/Win/WiX/HPCCSystemsGraphViewControlInstaller.wxs
-    PluginDLLGroup
-    ${FB_BIN_DIR}/${PLUGIN_NAME}/${CMAKE_CFG_INTDIR}/
-    ${FB_BIN_DIR}/${PLUGIN_NAME}/${CMAKE_CFG_INTDIR}/${FBSTRING_PluginFileName}.dll
-    ${PROJECT_NAME}
-    )
-
-# This is an example of how to add a build step to sign the WiX installer
-# -- uncomment lines below this to enable signing --
-firebreath_sign_file("${PLUGIN_NAME}_WiXInstall"
-    "${FB_BIN_DIR}/${PLUGIN_NAME}/${CMAKE_CFG_INTDIR}/${PLUGIN_NAME}.msi"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../sign/hpcc_code_signing.pfx"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../sign/passphrase.txt"
-    "http://timestamp.verisign.com/scripts/timestamp.dll")
+install ( TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin LIBRARY DESTINATION lib )


### PR DESCRIPTION
Regression in Issue-114 caused main dll to be excluded from windows package.

When WITH_DYNAMIC_MSVC_RUNTIME is false it included redundant MS runtime
libraries.

Fixes gh-123

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
