### PR TITLE
GH-127 GetLocalisedXGMML gathers too many vertices

### DIFF
--- a/graphdb/GraphDB.cpp
+++ b/graphdb/GraphDB.cpp
@@ -165,7 +165,10 @@ void WalkEdges(const IGraph * graph, std::string & content)
 			IVertex * from = e->GetFromVertex();
 			IVertex * to = e->GetToVertex();
 			if (from->GetPropertyInt(XGMML_GLOBAL_USAGE_COUNT) > 0)
+			{
+				assert(false);  //Edges of this type should have been removed by the XGMML parser.
 				continue;
+			}
 
 			//if (from->GetPropertyBool(XGMML_IS_SPILL) && (from->GetParent() != to->GetParent()) && from->GetOutEdgeCount() > 1)
 			//	continue;

--- a/graphdb/XgmmlParser.cpp
+++ b/graphdb/XgmmlParser.cpp
@@ -191,8 +191,12 @@ public:
 		StringGraphItemMap::const_iterator to = m_itemLookup.find(target);
 		assert(from != m_itemLookup.end());
 		assert(to != m_itemLookup.end());
-				//top->item = m_graph->CreateEdge(dynamic_cast<IVertex *>(from->second.get()), dynamic_cast<IVertex *>(to->second.get()));
-		retVal = hpcc::GetEdge(m_graph, id, dynamic_cast<IVertex *>(from->second.get()), dynamic_cast<IVertex *>(to->second.get()), m_merge);
+
+		IVertex * from_vertex = dynamic_cast<IVertex *>(from->second.get());
+		if (from_vertex->GetPropertyInt(XGMML_GLOBAL_USAGE_COUNT) > 0)
+			return NULL;
+
+		retVal = hpcc::GetEdge(m_graph, id, from_vertex, dynamic_cast<IVertex *>(to->second.get()), m_merge);
 		m_itemLookup[id] = retVal;
 		return retVal;
 	}
@@ -254,7 +258,8 @@ public:
 				edge = GetEdge(e->m_attr["id"], itrSource->second, itrTarget->second);
 			else
 				edge = GetEdge(e->m_attr["id"], e->m_attr["source"], e->m_attr["target"]);
-			assert(edge);
+			if (!edge)
+				continue;
 
 			for(ciStringStringMap::const_iterator itr = e->m_attr.begin(); itr != e->m_attr.end(); ++itr)
 				edge->SetProperty(itr->first, itr->second);


### PR DESCRIPTION
Filter out global data to activity edges during XGMML parse and not during DOT
file generation.

Fixes GH-127

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
