### PR TITLE
Issue_151 Improve GetLocalisedXGMML

### DIFF
--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
@@ -309,6 +309,7 @@ bool HPCCSystemsGraphViewControl::MergeSVG(const std::string & svg)
 {
 	if (hpcc::MergeSVG(m_g, svg))
 	{
+		m_svg = svg;
 		CalcScrollbars();
 		CenterOnGraphItem(NULL);
 		Invalidate();
@@ -500,13 +501,15 @@ const char * HPCCSystemsGraphViewControl::GetProperty(int _item, const std::stri
 
 unsigned int HPCCSystemsGraphViewControl::GetItem(const std::string &externalID)
 {
+	if (externalID.compare("0") == 0)
+		return m_g->GetID();
 	if (hpcc::IGraphItem * item = m_g->GetVertex(externalID, true))
 		return item->GetID();
 	if (hpcc::IGraphItem * item = m_g->GetEdge(externalID, true))
 		return item->GetID();
 	if (hpcc::IGraphItem * item = m_g->GetCluster(externalID, true))
 		return item->GetID();
-	return 0;
+	return -1;
 }
 
 const char * HPCCSystemsGraphViewControl::GetGlobalID(int item)
@@ -687,16 +690,11 @@ void HPCCSystemsGraphViewControl::FinishLayout()
 			m_pendingSvg = "";
 			return;
 		}
-
-		m_svg = m_pendingSvg;
-		hpcc::MergeSVG(m_g, m_pendingSvg);
+		MergeSVG(m_pendingSvg);
 		m_pendingDot = "";
 		m_pendingSvg = "";
 	}
 
-	CalcScrollbars();
-	CenterOnGraphItem(NULL);
-	Invalidate();
 	boost::static_pointer_cast<HPCCSystemsGraphViewControlAPI>(getRootJSAPI())->fire_LayoutFinished();
 }
 

--- a/README
+++ b/README
@@ -29,7 +29,7 @@ cd ..
 #### Get Firebreath library #### 
 git clone https://github.com/GordonSmith/FireBreath.git
 cd FireBreath
-git checkout closedown-4.0.x
+git checkout closedown-5.0.x
 cd ..
 
 #### Get unrestricted (2.4) agg libraries #### 

--- a/graphrender/GraphRender.cpp
+++ b/graphrender/GraphRender.cpp
@@ -815,7 +815,7 @@ public:
 
 			if (!m_message.empty())
 			{
-				m_agg2d.text(12, 12, m_message.c_str());
+				m_agg2d.text(_rect.left + 2, _rect.top + 14, m_message.c_str());
 			}
 			else if (HitTestItemFast(m_g, m_renderRect))
 			{


### PR DESCRIPTION
Dedup common edges between subgraphs.
Improve "0" level support.
Ensure top level self contained clusters are included.
Ensure message text is always visible.
Caching of SVG ignored externally merged SVG.

Fixes Issue_151

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
