### PR TITLE
HPCC-11201 Add "getTreeWithProperties" to GraphControl

### DIFF
--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.cpp
@@ -143,12 +143,12 @@ void HPCCSystemsGraphViewControl::InvalidateWorldRect(const hpcc::RectD & worldR
 
 int HPCCSystemsGraphViewControl::GetScrollOffsetX()
 {
-	return m_ptOffset.x;
+	return static_cast<int>(m_ptOffset.x);
 }
 
 int HPCCSystemsGraphViewControl::GetScrollOffsetY()
 {
-	return m_ptOffset.y;
+	return static_cast<int>(m_ptOffset.y);
 }
 
 void HPCCSystemsGraphViewControl::SetScrollOffset(int x, int y)
@@ -708,8 +708,8 @@ bool HPCCSystemsGraphViewControl::onMouseMove(FB::MouseMoveEvent *evt, FB::Plugi
 	case MOUSEDOWN_NORMAL:
 	case MOUSEDOWN_MOVED:
 		{
-			int deltaX = point.x - m_mouseDownPosX;
-			int deltaY = point.y - m_mouseDownPosY;
+			int deltaX = static_cast<int>(point.x - m_mouseDownPosX);
+			int deltaY = static_cast<int>(point.y - m_mouseDownPosY);
 
 			SetScrollOffset(m_scrollDownPosX - deltaX, m_scrollDownPosY - deltaY);
 			if (deltaX || deltaY)
@@ -754,7 +754,7 @@ bool HPCCSystemsGraphViewControl::onMouseScroll(FB::MouseScrollEvent *evt, FB::P
 			m_gr->SetScale(scale - 0.05 * scale);
 
 		CalcScrollbars();
-		MoveTo(worldDblClk, pt.x, pt.y);
+		MoveTo(worldDblClk, static_cast<int>(pt.x), static_cast<int>(pt.y));
 
 		boost::static_pointer_cast<HPCCSystemsGraphViewControlAPI>(getRootJSAPI())->fire_Scaled((int)(m_gr->GetScale() * 100));
 	} else {
@@ -766,7 +766,7 @@ bool HPCCSystemsGraphViewControl::onMouseScroll(FB::MouseScrollEvent *evt, FB::P
 		pt.x += delta.x;
 		pt.y += delta.y;
 
-		MoveTo(worldDblClk, pt.x, pt.y);
+		MoveTo(worldDblClk, static_cast<int>(pt.x), static_cast<int>(pt.y));
 	}
     return true;
 }
@@ -801,7 +801,7 @@ bool HPCCSystemsGraphViewControl::onRefresh(FB::RefreshEvent *evt, FB::PluginWin
 
 	hpcc::RectI bounds(0, 0, evt->bounds.right, evt->bounds.bottom);
 	hpcc::RectI rect(bounds);
-	rect.Offset(m_ptOffset.x, m_ptOffset.y);
+	rect.Offset(static_cast<int>(m_ptOffset.x), static_cast<int>(m_ptOffset.y));
 
 	m_buffer->Resize(rect.Width(), rect.Height());
 	m_gr->DoRender(rect, true);

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.h
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControl.h
@@ -126,9 +126,12 @@ public:
 	void SetProperty(int item, const std::string & key, const std::string & value);
 	const char * GetProperty(int item, const std::string & key);
 	unsigned int GetParent(int item);
+	int GetChildSubgraphs(int item, std::vector<int> & results);
+	int GetChildVertices(int item, std::vector<int> & results);
 	int GetChildren(int item, std::vector<int> & results);
 	int GetInEdges(int item, std::vector<int> & results);
 	int GetOutEdges(int item, std::vector<int> & results);
+	unsigned int GetGraph();
 	unsigned int GetSource(int item);
 	unsigned int GetTarget(int item);
 	unsigned int GetItem(const std::string &externalID);

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.cpp
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.cpp
@@ -337,6 +337,27 @@ FB::VariantList HPCCSystemsGraphViewControlAPI::getVertices()
 	return items;
 }
 
+FB::VariantMap HPCCSystemsGraphViewControlAPI::walkTree(int parent)
+{
+	FB::VariantMap retVal = getProperties(parent);
+	std::vector<int> children;
+	getPlugin()->GetChildren(parent, children);
+	FB::VariantList childList;
+	for(std::vector<int>::const_iterator itr = children.begin(); itr != children.end(); ++itr)
+		childList.push_back(walkTree(*itr));
+	if (!childList.empty())
+		retVal[hpcc::CALC_PROP_CHILDREN] = childList;
+	return retVal;
+}
+
+FB::VariantList HPCCSystemsGraphViewControlAPI::getTreeWithProperties()
+{
+	FB::VariantList retVal;
+	unsigned int rootID = getPlugin()->GetItem("0");
+	retVal.push_back(walkTree(rootID));
+	return retVal;
+}
+
 FB::VariantList HPCCSystemsGraphViewControlAPI::getSubgraphsWithProperties()
 {
 	std::vector<int> subgraphs;

--- a/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.h
+++ b/HPCCSystemsGraphViewControl/HPCCSystemsGraphViewControlAPI.h
@@ -95,6 +95,7 @@ public:
 		registerMethod("getDOT", make_method(this, &HPCCSystemsGraphViewControlAPI::getDOT));
 		registerMethod("getLocalisedXGMML", make_method(this, &HPCCSystemsGraphViewControlAPI::getLocalisedXGMML));
 
+		registerMethod("getTreeWithProperties", make_method(this, &HPCCSystemsGraphViewControlAPI::getTreeWithProperties));
 		registerMethod("getSubgraphsWithProperties", make_method(this, &HPCCSystemsGraphViewControlAPI::getSubgraphsWithProperties));
 		registerMethod("getVerticesWithProperties", make_method(this, &HPCCSystemsGraphViewControlAPI::getVerticesWithProperties));
 		registerMethod("getEdgesWithProperties", make_method(this, &HPCCSystemsGraphViewControlAPI::getEdgesWithProperties));
@@ -161,6 +162,8 @@ public:
 	std::string getGlobalType(int item);
 	std::string getGlobalID(int item);
 
+	FB::VariantMap walkTree(int parent);
+	FB::VariantList getTreeWithProperties();
 	FB::VariantList getSubgraphsWithProperties();
 
 	FB::VariantList getVertices();

--- a/graphdb/GraphCluster.cpp
+++ b/graphdb/GraphCluster.cpp
@@ -48,6 +48,28 @@ ICluster * CCluster::GetParent() const
 	return m_parent;
 }
 
+unsigned int CCluster::GetDepth() const
+{
+	if (m_parent)
+		return m_parent->GetDepth() + 1;
+
+	return 1;
+}
+
+unsigned int CCluster::GetChildCount() const
+{
+	return m_clusters.size() + m_vertices.size();
+}
+
+unsigned int CCluster::GetDescendentCount() const
+{
+	unsigned int retVal = GetChildCount();
+	for(IClusterSet::const_iterator itr = m_clusters.begin(); itr != m_clusters.end(); ++itr)
+		retVal += itr->get()->GetDescendentCount();
+
+	return retVal;
+}
+
 void CCluster::MoveTo(ICluster * cluster)
 {
 	if (m_parent != cluster)

--- a/graphdb/GraphCluster.h
+++ b/graphdb/GraphCluster.h
@@ -46,7 +46,10 @@ public:
 
 	//  ===  ICluster  ===
 	ICluster * GetParent() const;
+	unsigned int GetDepth() const;
 	void MoveTo(ICluster * cluster);
+	unsigned int GetChildCount() const;
+	unsigned int GetDescendentCount() const;
 	const IClusterSet & GetClusters() const;
 	const IVertexSet & GetVertices() const;
 	void AppendCluster(ICluster * cluster);
@@ -59,6 +62,9 @@ public:
 };
 
 #define ICLUSTER_IMPL	ICluster * GetParent() const { return CCluster::GetParent(); } \
+						unsigned int GetDepth() const {return CCluster::GetDepth(); } \
+						unsigned int GetChildCount() const {return CCluster::GetChildCount(); } \
+						unsigned int GetDescendentCount() const {return CCluster::GetDescendentCount(); } \
 						void MoveTo(ICluster * cluster) { CCluster::MoveTo(cluster); } \
 						const IClusterSet & GetClusters() const { return CCluster::GetClusters(); } \
 						const IVertexSet & GetVertices() const { return CCluster::GetVertices(); } \

--- a/graphdb/GraphDB.cpp
+++ b/graphdb/GraphDB.cpp
@@ -453,6 +453,10 @@ public:
 	{
 		if (m_visibleClusters.find(cluster) != m_visibleClusters.end())
 		{
+			std::string propsStr;
+			ciStringStringMap props;
+			cluster->GetProperties(props);
+
 			m_xgmml += (boost::format("<node id=\"%1%\"><att><graph>") % cluster->GetProperty("id")).str();
 			int xgmmlLen = m_xgmml.length();
 			cluster->Walk((IClusterVisitor *) this);
@@ -467,7 +471,10 @@ public:
 					m_xgmml += vertexString;
 				}
 			}
-			m_xgmml += "</graph></att></node>";
+
+			for(ciStringStringMap::const_iterator itr = props.begin(); itr != props.end(); ++itr)
+				propsStr += (boost::format("<att name=\"%1%\" value=\"%2%\"/>") % itr->first % xmlEncode(itr->second)).str();
+			m_xgmml += (boost::format("</graph></att>%1%</node>") % propsStr).str();
 		}
 		return false;
 	}

--- a/graphdb/GraphDB.h
+++ b/graphdb/GraphDB.h
@@ -136,6 +136,9 @@ hpcc_interface GRAPHDB_API IGraphItem : public IUnknown
 hpcc_interface GRAPHDB_API ICluster : public IGraphItem
 {
 	virtual ICluster * GetParent() const = 0;
+	virtual unsigned int GetDepth() const = 0;
+	virtual unsigned int GetChildCount() const = 0;
+	virtual unsigned int GetDescendentCount() const = 0;
 	virtual void MoveTo(ICluster * cluster) = 0;
 	virtual const IClusterSet & GetClusters() const = 0;
 	virtual const IVertexSet & GetVertices() const = 0;
@@ -152,6 +155,7 @@ hpcc_interface GRAPHDB_API ICluster : public IGraphItem
 hpcc_interface GRAPHDB_API IVertex : public IGraphItem
 {
 	virtual ICluster * GetParent() const = 0;
+	virtual unsigned int GetDepth() const = 0;
 	virtual void MoveTo(ICluster * cluster) = 0;
 	virtual unsigned int GetInEdgeCount() const = 0;
 	virtual unsigned int GetOutEdgeCount() const = 0;

--- a/graphdb/GraphVertex.cpp
+++ b/graphdb/GraphVertex.cpp
@@ -36,6 +36,10 @@ ICluster * CVertex::GetParent() const
 {
 	return m_parent;
 }
+unsigned int CVertex::GetDepth() const
+{
+	return m_parent->GetDepth() + 1;
+}
 
 void CVertex::MoveTo(ICluster * cluster) 
 {

--- a/graphdb/GraphVertex.h
+++ b/graphdb/GraphVertex.h
@@ -44,6 +44,7 @@ public:
 
 	//  ===  IVertex  ===
 	ICluster * GetParent() const;
+	unsigned int GetDepth() const;
 	void MoveTo(ICluster * cluster);
 	unsigned int GetInEdgeCount() const;
 	unsigned int GetOutEdgeCount() const;

--- a/graphdb/XgmmlParser.cpp
+++ b/graphdb/XgmmlParser.cpp
@@ -405,6 +405,15 @@ public:
 
 };
 
+void calcProps(ICluster * item)
+{
+	item->SetProperty(CALC_PROP_DEPTH, boost::lexical_cast<std::string>(item->GetDepth()));
+	item->SetProperty(CALC_PROP_SUBGRAPHCOUNT, boost::lexical_cast<std::string>(item->GetClusters().size()));
+	item->SetProperty(CALC_PROP_ACTIVITYCOUNT, boost::lexical_cast<std::string>(item->GetVertices().size()));
+	item->SetProperty(CALC_PROP_CHILDCOUNT, boost::lexical_cast<std::string>(item->GetChildCount()));
+	item->SetProperty(CALC_PROP_DESCENDANTCOUNT, boost::lexical_cast<std::string>(item->GetDescendentCount()));
+}
+
 GRAPHDB_API bool LoadXGMML(IGraph * graph, const std::string & xgmml)
 {
 	CXgmmlParser parser(graph, false);
@@ -448,6 +457,10 @@ GRAPHDB_API bool LoadXGMML(IGraph * graph, const std::string & xgmml)
 		}
 	}
 #endif
+
+	calcProps(graph);
+	for(IClusterSet::const_iterator itr = graph->GetAllClusters().begin(); itr != graph->GetAllClusters().end(); ++itr)
+		calcProps(itr->get());
 
 	return retVal;
 }

--- a/graphdb/XgmmlParser.h
+++ b/graphdb/XgmmlParser.h
@@ -43,6 +43,13 @@ enum XGMML_STATE_ENUM
 	XGMML_STATE_LAST
 };
 
+const char * const CALC_PROP_DEPTH = "Depth";
+const char * const CALC_PROP_SUBGRAPHCOUNT = "SubgraphCount";
+const char * const CALC_PROP_ACTIVITYCOUNT = "ActivityCount";
+const char * const CALC_PROP_CHILDCOUNT = "ChildCount";
+const char * const CALC_PROP_DESCENDANTCOUNT = "DescendantCount";
+const char * const CALC_PROP_CHILDREN = "_children";
+
 ICluster * GetCluster(IGraph* graph, ICluster* cluster, unsigned int id, const std::string & label, bool merge, bool appendMissing);
 ICluster * GetCluster(IGraph* graph, ICluster* cluster, const std::string & id, bool merge, bool appendMissing = true);
 IVertex * GetVertex(IGraph* graph, ICluster* cluster, const std::string & id, bool merge, bool appendMissing = true);


### PR DESCRIPTION
Fixed compiler cast warnings (double to int).

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
