### PR TITLE
HPCC-11264 Register GraphControl Per Machine

### DIFF
--- a/HPCCSystemsGraphViewControl/PluginConfig.cmake
+++ b/HPCCSystemsGraphViewControl/PluginConfig.cmake
@@ -71,4 +71,4 @@ set(FBMAC_USE_COREANIMATION 0)
 set(FBMAC_USE_INVALIDATINGCOREANIMATION 0)
 
 # If you want to register per-machine on Windows, uncomment this line
-#set (FB_ATLREG_MACHINEWIDE 1)
+set (FB_ATLREG_MACHINEWIDE 1)


### PR DESCRIPTION
This is a workaround for the following anomaly (either by installer or RegSvr32):
1.  Install 32bit graph control as Administrator
2.  Install 64bit graph control as Administrator
Control will not work in Chrome (32bit) when user is not Administrator.

Fixes HPCC-11264

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
