### PR TITLE
HPCC-13086 Simplify FontResolver on Linux

### DIFF
--- a/graphrender/FontResolver.cpp
+++ b/graphrender/FontResolver.cpp
@@ -9,7 +9,7 @@ namespace hpcc
 #define DEFAULT_FONT "ArialUni;Arial;Verdana"
 #elif defined FB_X11
 /* default fontpath for unix systems  - whatever happened to standards ! */
-#define DEFAULT_FONTPATH "/usr/X11R6/lib/X11/fonts/TrueType;/usr/X11R6/lib/X11/fonts/truetype;/usr/X11R6/lib/X11/fonts/TTF;/usr/share/fonts/TrueType;/usr/share/fonts/truetype;/usr/openwin/lib/X11/fonts/TrueType;/usr/X11R6/lib/X11/fonts/Type1;/usr/lib/X11/fonts/Type1;/usr/openwin/lib/X11/fonts/Type1"
+#define DEFAULT_FONTPATH "/usr/X11R6/lib/X11/fonts;/usr/share/fonts;/usr/openwin/lib/X11/fonts;/usr/lib/X11/fonts"
 #define DEFAULT_FONT "wqy-zenhei;DejaVu Sans;DejaVuSans;Liberation Sans;FreeSans;Verdana"
 #elif defined FB_MACOSX	
 #define DEFAULT_FONTPATH "/Library/Fonts;/System/Library/Fonts"


### PR DESCRIPTION
Default the search folder up one level:
xxx/yyy/TrueType->xxx/yyy

Fixes HPCC-13086

Signed-off-by: Gordon Smith <gordon.smith@lexisnexis.com>